### PR TITLE
Display: table concerns

### DIFF
--- a/inst/rmarkdown/templates/dc_lesson_template/resources/style.css
+++ b/inst/rmarkdown/templates/dc_lesson_template/resources/style.css
@@ -119,7 +119,7 @@ img.image-thumb {
 
 .figure {
     margin: 5px auto 30px auto;
-    display: table;
+    display: block;
 }
 
 .figure img {


### PR DESCRIPTION
Hi @karthik  - thanks for putting this template together. Some folks [pointed out](https://github.com/ropenscilabs/r-docker-tutorial/issues/12) over on the docker lesson that uses this template, that the `display: table` CSS used in your `figure` class causes problems in some builds of FF. In general, pain can be avoided by not using tables or `display:table` for anything except literal tables; this PR currently simply changes the `.figure` class to `display:block`.

Are there any tests / things to check to make sure this doesn't mangle something else? Would like to do a bit more to understand the original design decision / validate this change before merge. Thanks!
